### PR TITLE
Viser morgendagens oppgaver etter split

### DIFF
--- a/MORGENDAGENS_TASKS_FEATURE.md
+++ b/MORGENDAGENS_TASKS_FEATURE.md
@@ -1,0 +1,123 @@
+# Morgendagens Tasks Feature
+
+Jeg har implementert en komplett feature som lar brukere se og administrere morgendagens tasks etter en split. Her er en oversikt over implementasjonen:
+
+## Implementerte Komponenter
+
+### 1. Tasks Context - Ny Funksjon
+**Fil:** `lib/daily_task/tasks.ex`
+
+Lagt til en ny funksjon `get_task_by_tomorrow/0` som:
+- Beregner morgendagens dato automatisk
+- Henter tasken for morgendagens dato fra databasen
+- Returnerer `nil` hvis ingen task finnes
+
+```elixir
+def get_task_by_tomorrow do
+  tomorrow = Date.add(Date.utc_today(), 1)
+  get_task_by_date(tomorrow)
+end
+```
+
+### 2. Tomorrow LiveView
+**Fil:** `lib/daily_task_web/live/task_live/tomorrow.ex`
+
+En komplett LiveView-modul som håndterer:
+- Visning av morgendagens task
+- Redigering av morgendagens task
+- Oppretting av nye tasks for i morgen
+- Sletting og fullføring av morgendagens tasks
+- Navigasjon tilbake til dagens tasks
+
+### 3. Tomorrow HTML Template
+**Fil:** `lib/daily_task_web/live/task_live/tomorrow.html.heex`
+
+En HTML-template på norsk som inkluderer:
+- Visning av morgendagens task med dato
+- Knapper for å fullføre, redigere og slette
+- Melding når ingen task finnes for i morgen
+- Knapp for å legge til ny task for i morgen
+- Navigasjonslenke tilbake til dagens tasks
+
+### 4. Router-oppdateringer
+**Fil:** `lib/daily_task_web/router.ex`
+
+Nye ruter lagt til:
+- `/tasks/tomorrow` - hovedside for morgendagens tasks
+- `/tasks/tomorrow/new` - ny task for i morgen
+- `/tasks/tomorrow/:id/edit` - rediger morgendagens task
+
+### 5. Navigasjon fra Dagens Tasks
+**Fil:** `lib/daily_task_web/live/task_live/index.html.heex`
+
+Lagt til en navigasjonsknapp på dagens task-side som lenker til morgendagens tasks:
+```html
+<.link navigate={~p"/tasks/tomorrow"} class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
+  Se morgendagens tasks →
+</.link>
+```
+
+### 6. Forbedret Split-funksjonalitet
+**Fil:** `lib/daily_task_web/live/task_live/index.ex`
+
+Oppdatert flash-meldingen når en task blir splittet:
+```elixir
+|> put_flash(:info, "Task splittet! Se morgendagens tasks for å se den andre delen.")
+```
+
+### 7. Tester
+**Filer:** 
+- `test/daily_task/tasks_test.exs` - tester for `get_task_by_tomorrow/0`
+- `test/daily_task_web/live/task_live_tomorrow_test.exs` - komplett testsuite for Tomorrow LiveView
+
+## Funksjonalitet
+
+### Brukerflyt
+1. **Fra dagens tasks:** Brukeren kan klikke "Se morgendagens tasks →" for å navigere til morgendagens side
+2. **Visning:** Hvis det finnes en task for i morgen, vises den med alle detaljer
+3. **Ingen task:** Hvis ingen task finnes, vises en melding og knapp for å lage ny task
+4. **Administrasjon:** Brukeren kan fullføre, redigere eller slette morgendagens task
+5. **Navigasjon:** Enkel tilbakenavigasjon til dagens tasks
+
+### Split-integrasjon
+- Når en task blir splittet, opprettes automatisk en task for i morgen
+- Brukeren får en informativ melding som oppfordrer til å sjekke morgendagens tasks
+- Den nye morgendagens task er umiddelbart tilgjengelig på `/tasks/tomorrow`
+
+### Tekst på Norsk
+Hele brukergrensesnittet er på norsk som forespurt:
+- "Morgendagens task"
+- "Ingen task for i morgen ennå"
+- "Legg til task for i morgen"
+- "Fullfør", "Rediger", "Slett"
+- "Tilbake til dagens tasks"
+
+## Teknisk Implementasjon
+
+### Kodekvalitet
+- Følger eksisterende kodestil og mønstre
+- Gjenbruker FormComponent for konsistens
+- Proper error handling og flash-meldinger
+- Responsive design med Tailwind CSS
+
+### Testing
+- Unit-tester for Tasks context-funksjonen
+- Integration-tester for LiveView-funksjonaliteten
+- Tester for alle CRUD-operasjoner
+- Tester for navigasjon og brukerinteraksjon
+
+### Sikkerhet og Robusthet
+- Sikker dato-håndtering med Elixir Date-modulen
+- Proper validering gjennom eksisterende changeset-logikk
+- Konsistent error handling
+
+## Bruk
+
+For å bruke den nye featureen:
+
+1. **Start applikasjonen:** `mix phx.server`
+2. **Gå til dagens tasks:** `/tasks`
+3. **Split en task** eller **naviger direkte til morgendagens tasks:** `/tasks/tomorrow`
+4. **Administrer morgendagens tasks** som ønsket
+
+Featureen integreres sømløst med eksisterende funksjonalitet og følger de samme designprinsippene som resten av applikasjonen.

--- a/lib/daily_task/tasks.ex
+++ b/lib/daily_task/tasks.ex
@@ -123,6 +123,25 @@ defmodule DailyTask.Tasks do
   end
 
   @doc """
+  Gets tomorrow's task.
+
+  Returns `nil` if no task exists for tomorrow.
+
+  ## Examples
+
+      iex> get_task_by_tomorrow()
+      %Task{}
+
+      iex> get_task_by_tomorrow()
+      nil
+
+  """
+  def get_task_by_tomorrow do
+    tomorrow = Date.add(Date.utc_today(), 1)
+    get_task_by_date(tomorrow)
+  end
+
+  @doc """
   Splits a task into two.
 
   The original task is updated with new attributes, and a new task is

--- a/lib/daily_task_web/live/task_live/index.ex
+++ b/lib/daily_task_web/live/task_live/index.ex
@@ -73,14 +73,14 @@ defmodule DailyTaskWeb.TaskLive.Index do
       {:ok, %{today: task, tomorrow: _}} ->
         {:noreply,
          socket
-         |> put_flash(:info, "Task split successfully")
+         |> put_flash(:info, "Task splittet! Se morgendagens tasks for å se den andre delen.")
          |> assign(task: task)
          |> push_patch(to: ~p"/tasks")}
 
       {:error, _} ->
         {:noreply,
          socket
-         |> put_flash(:error, "There was an error splitting the task.")
+         |> put_flash(:error, "Det oppstod en feil under splitting av tasken.")
          |> push_patch(to: ~p"/tasks")}
     end
   end

--- a/lib/daily_task_web/live/task_live/index.html.heex
+++ b/lib/daily_task_web/live/task_live/index.html.heex
@@ -47,6 +47,13 @@
       </div>
     </div>
 
+    <!-- Navigasjon til morgendagens tasks -->
+    <div class="mt-8 text-center">
+      <.link navigate={~p"/tasks/tomorrow"} class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
+        Se morgendagens tasks →
+      </.link>
+    </div>
+
     <div :if={@live_action == :split} class="relative z-50">
       <.modal id="split-modal" show on_cancel={JS.patch(~p"/")}>
         <.simple_form

--- a/lib/daily_task_web/live/task_live/tomorrow.ex
+++ b/lib/daily_task_web/live/task_live/tomorrow.ex
@@ -1,0 +1,70 @@
+defmodule DailyTaskWeb.TaskLive.Tomorrow do
+  use DailyTaskWeb, :live_view
+
+  alias DailyTask.Tasks
+  alias DailyTask.Tasks.Task
+
+  @impl true
+  def mount(_params, _session, socket) do
+    today = Date.utc_today()
+    tomorrow = Date.add(today, 1)
+    tomorrow_task = Tasks.get_task_by_tomorrow()
+
+    socket =
+      assign(socket,
+        today: today,
+        tomorrow: tomorrow,
+        tomorrow_task: tomorrow_task
+      )
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  defp apply_action(socket, :edit, %{"id" => id}) do
+    socket
+    |> assign(:page_title, "Rediger morgendagens task")
+    |> assign(:task, Tasks.get_task!(id))
+  end
+
+  defp apply_action(socket, :new, _params) do
+    socket
+    |> assign(:page_title, "Ny task for i morgen")
+    |> assign(:task, %Task{date: socket.assigns.tomorrow})
+  end
+
+  defp apply_action(socket, :index, _params) do
+    socket
+    |> assign(:page_title, "Morgendagens task")
+    |> assign(:task, Tasks.get_task_by_tomorrow())
+  end
+
+  @impl true
+  def handle_event("delete", %{"id" => id}, socket) do
+    task = Tasks.get_task!(id)
+    {:ok, _} = Tasks.delete_task(task)
+
+    {:noreply, assign(socket, :tomorrow_task, nil)}
+  end
+
+  @impl true
+  def handle_event("complete", %{"id" => id}, socket) do
+    task = Tasks.get_task!(id)
+    {:ok, updated_task} = Tasks.update_task(task, %{completed: true})
+
+    {:noreply, assign(socket, :tomorrow_task, updated_task)}
+  end
+
+  @impl true
+  def handle_info({DailyTaskWeb.TaskLive.FormComponent, {:saved, task}}, socket) do
+    {:noreply,
+     socket
+     |> put_flash(:info, "Task lagret")
+     |> assign(tomorrow_task: task)
+     |> push_patch(to: ~p"/tasks/tomorrow")}
+  end
+end

--- a/lib/daily_task_web/live/task_live/tomorrow.html.heex
+++ b/lib/daily_task_web/live/task_live/tomorrow.html.heex
@@ -1,0 +1,66 @@
+<div class="w-full bg-background text-foreground">
+  <div class="mx-auto max-w-2xl px-4 py-10">
+    <.header class="text-center">
+      <%= @page_title %>
+      <:subtitle>
+        <%= @tomorrow %>
+      </:subtitle>
+    </.header>
+
+    <div class="mt-8">
+      <div :if={@tomorrow_task} class="space-y-4">
+        <div class="rounded-lg border bg-card text-card-foreground shadow-sm p-6">
+          <div class="flex items-center justify-between">
+            <p class={["text-lg", @tomorrow_task.completed && "line-through"]}>
+              <%= @tomorrow_task.description %>
+            </p>
+            <div :if={@tomorrow_task.id} class="flex items-center space-x-2">
+              <.button
+                :if={!@tomorrow_task.completed}
+                phx-click="complete"
+                phx-value-id={@tomorrow_task.id}
+              >
+                Fullfør
+              </.button>
+              <.link patch={~p"/tasks/tomorrow/#{@tomorrow_task.id}/edit"} aria-label={"edit-task-#{@tomorrow_task.id}"}>
+                <.button>Rediger</.button>
+              </.link>
+              <.link
+                phx-click={JS.push("delete", value: %{id: @tomorrow_task.id})}
+                data-confirm="Er du sikker?"
+                aria-label={"delete-task-#{@tomorrow_task.id}"}
+              >
+                <.button>Slett</.button>
+              </.link>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div :if={is_nil(@tomorrow_task)} class="text-center">
+        <p class="text-muted-foreground">Ingen task for i morgen ennå.</p>
+        <.link patch={~p"/tasks/tomorrow/new"} class="mt-4 inline-block">
+          <.button>Legg til task for i morgen</.button>
+        </.link>
+      </div>
+    </div>
+
+    <!-- Navigasjon tilbake til dagens tasks -->
+    <div class="mt-8 text-center">
+      <.link navigate={~p"/tasks"} class="text-blue-600 hover:text-blue-800">
+        ← Tilbake til dagens tasks
+      </.link>
+    </div>
+  </div>
+</div>
+
+<.modal :if={@live_action in [:new, :edit]} id="task-modal" show on_cancel={JS.patch(~p"/tasks/tomorrow")}>
+  <.live_component
+    module={DailyTaskWeb.TaskLive.FormComponent}
+    id={@task.id || :new}
+    title={@page_title}
+    action={@live_action}
+    task={@task}
+    today={@tomorrow}
+    patch={~p"/tasks/tomorrow"}
+  />
+</.modal>

--- a/lib/daily_task_web/router.ex
+++ b/lib/daily_task_web/router.ex
@@ -26,6 +26,10 @@ defmodule DailyTaskWeb.Router do
     live "/tasks/new", TaskLive.Index, :new
     live "/tasks/:id/edit", TaskLive.Index, :edit
     live "/tasks/:id/split", TaskLive.Index, :split
+
+    live "/tasks/tomorrow", TaskLive.Tomorrow, :index
+    live "/tasks/tomorrow/new", TaskLive.Tomorrow, :new
+    live "/tasks/tomorrow/:id/edit", TaskLive.Tomorrow, :edit
   end
 
   # Other scopes may use custom stacks.

--- a/test/daily_task/tasks_test.exs
+++ b/test/daily_task/tasks_test.exs
@@ -59,5 +59,16 @@ defmodule DailyTask.TasksTest do
       task = task_fixture()
       assert %Ecto.Changeset{} = Tasks.change_task(task)
     end
+
+    test "get_task_by_tomorrow/0 returns tomorrow's task when it exists" do
+      tomorrow = Date.add(Date.utc_today(), 1)
+      task = task_fixture(%{date: tomorrow, description: "Tomorrow's task"})
+      
+      assert Tasks.get_task_by_tomorrow() == task
+    end
+
+    test "get_task_by_tomorrow/0 returns nil when no task exists for tomorrow" do
+      assert Tasks.get_task_by_tomorrow() == nil
+    end
   end
 end

--- a/test/daily_task_web/live/task_live_tomorrow_test.exs
+++ b/test/daily_task_web/live/task_live_tomorrow_test.exs
@@ -1,0 +1,87 @@
+defmodule DailyTaskWeb.TaskLive.TomorrowTest do
+  use DailyTaskWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import DailyTask.TasksFixtures
+
+  @invalid_attrs %{description: ""}
+
+  setup %{conn: conn} do
+    today = Date.utc_today()
+    tomorrow = Date.add(today, 1)
+    %{conn: bypass_through(conn, [DailyTaskWeb.UserAuth]) |> assign(:current_user, nil), today: today, tomorrow: tomorrow}
+  end
+
+  describe "Tomorrow Index" do
+    test "displays add task button when no task exists for tomorrow", %{conn: conn} do
+      {:ok, _index_live, html} = live(conn, ~p"/tasks/tomorrow")
+      assert html =~ "Ingen task for i morgen ennå"
+      assert html =~ "Legg til task for i morgen"
+    end
+
+    test "displays tomorrow's task when one exists", %{conn: conn, tomorrow: tomorrow} do
+      _task = task_fixture(%{date: tomorrow, description: "Morgendagens task"})
+      {:ok, _index_live, html} = live(conn, ~p"/tasks/tomorrow")
+
+      assert html =~ "Morgendagens task"
+      refute html =~ "Ingen task for i morgen ennå"
+    end
+
+    test "creates a new task for tomorrow", %{conn: conn, tomorrow: tomorrow} do
+      {:ok, index_live, _html} = live(conn, ~p"/tasks/tomorrow/new")
+      create_attrs = %{description: "En ny task for i morgen"}
+
+      index_live
+      |> form("#task-form", task: create_attrs)
+      |> render_submit()
+
+      html = render(index_live)
+      assert html =~ "Task lagret"
+      assert html =~ "En ny task for i morgen"
+
+      assert %{description: "En ny task for i morgen", date: ^tomorrow} =
+               DailyTask.Tasks.get_task_by_date(tomorrow)
+    end
+
+    test "updates tomorrow's task", %{conn: conn, tomorrow: tomorrow} do
+      task = task_fixture(%{date: tomorrow})
+      {:ok, index_live, _html} = live(conn, ~p"/tasks/tomorrow/#{task.id}/edit")
+
+      update_attrs = %{description: "Oppdatert morgendagens task"}
+      index_live
+      |> form("#task-form", task: update_attrs)
+      |> render_submit()
+
+      html = render(index_live)
+      assert html =~ "Task lagret"
+      assert html =~ "Oppdatert morgendagens task"
+    end
+
+    test "deletes tomorrow's task", %{conn: conn, tomorrow: tomorrow} do
+      task = task_fixture(%{date: tomorrow})
+      {:ok, index_live, _html} = live(conn, ~p"/tasks/tomorrow")
+
+      index_live
+      |> element(~s/a[aria-label="delete-task-#{task.id}"]/)
+      |> render_click()
+
+      assert_raise Ecto.NoResultsError, fn -> DailyTask.Tasks.get_task!(task.id) end
+    end
+
+    test "completes tomorrow's task", %{conn: conn, tomorrow: tomorrow} do
+      task = task_fixture(%{date: tomorrow, completed: false})
+      {:ok, index_live, _html} = live(conn, ~p"/tasks/tomorrow")
+
+      index_live |> element(~s/button[phx-value-id="#{task.id}"]/, "Fullfør") |> render_click()
+
+      html = render(index_live)
+      assert html =~ "line-through"
+      assert DailyTask.Tasks.get_task!(task.id).completed
+    end
+
+    test "shows navigation back to today's tasks", %{conn: conn} do
+      {:ok, _index_live, html} = live(conn, ~p"/tasks/tomorrow")
+      assert html =~ "Tilbake til dagens tasks"
+    end
+  end
+end


### PR DESCRIPTION
A new feature was implemented to display and manage tomorrow's tasks.

*   A `get_task_by_tomorrow/0` function was added to `lib/daily_task/tasks.ex` to retrieve the task scheduled for the next day.
*   A new LiveView, `DailyTaskWeb.TaskLive.Tomorrow`, was created in `lib/daily_task_web/live/task_live/tomorrow.ex` to handle the display, creation, editing, completion, and deletion of tomorrow's task.
*   Its corresponding HTML template, `lib/daily_task_web/live/task_live/tomorrow.html.heex`, was added to render the UI, including a form component for task management and navigation.
*   `lib/daily_task_web/router.ex` was updated with new routes for `/tasks/tomorrow`, `/tasks/tomorrow/new`, and `/tasks/tomorrow/:id/edit` to support the new LiveView.
*   A navigation link to "tomorrow's tasks" was added to `lib/daily_task_web/live/task_live/index.html.heex` for easy access.
*   The split task feedback message in `lib/daily_task_web/live/task_live/index.ex` was updated to inform the user about checking tomorrow's tasks.
*   Tests were added in `test/daily_task/tasks_test.exs` for the new `get_task_by_tomorrow/0` function and in `test/daily_task_web/live/task_live_tomorrow_test.exs` for the new Tomorrow LiveView's functionality.
*   A documentation file, `MORGENDAGENS_TASKS_FEATURE.md`, was created to summarize the new feature.